### PR TITLE
Fixed Speaker List Not Being Erased

### DIFF
--- a/client/Plugin.cpp
+++ b/client/Plugin.cpp
@@ -478,7 +478,11 @@ void Plugin::ControlPacketHandler(const ControlPacket& controlPacket)
             if (controlPacket.length != sizeof(stData)) break;
 
             Logger::LogToFile("[sv:dbg:plugin:deletestream] : stream(%p)", stData.stream);
-
+            
+            const auto iter = Plugin::streamTable.find(stData.stream);
+            if (iter == Plugin::streamTable.end()) break;
+            for (WORD playerId{ 0 }; playerId < MAX_PLAYERS; ++playerId) SpeakerList::OnSpeakerStop(*(iter->second), playerId);
+            
             Plugin::streamTable.erase(stData.stream);
         } break;
         case SV::ControlPacketType::setStreamParameter:


### PR DESCRIPTION
There is a bug that if you get out of a player stream if the player was talking his name won't erase from you speaker list and will stick there until the player disconnects.
This RP will fix this problem.

@CyberMor Please make a release after this because the last release has a bug that clients cannot hear any stream at all.
Thank you.

I'm retired from SA-MP and I like to make these PRs to help others develop their servers faster and not stuck in problems like me ;D